### PR TITLE
SemaphoreCI is still using thriqon/involucro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Involucro - Build and Deliver Software with Containers
 
 [![Build Status](https://travis-ci.org/involucro/involucro.svg?branch=master)](https://travis-ci.org/involucro/involucro)
-[![Build Status](https://semaphoreci.com/api/v1/involucro/involucro/branches/master/badge.svg)](https://semaphoreci.com/involucro/involucro)
+[![Build Status](https://semaphoreci.com/api/v1/thriqon/involucro/branches/master/badge.svg)](https://semaphoreci.com/involucro/involucro)
 [![Build status](https://ci.appveyor.com/api/projects/status/ice63amutmub3qqr/branch/master?svg=true)](https://ci.appveyor.com/project/JonasWeber/involucro/branch/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/involucro/involucro)](https://goreportcard.com/report/github.com/involucro/involucro)
 [![Gitter](https://badges.gitter.im/involucro/involucro.svg)](https://gitter.im/involucro/involucro?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
Changed in README

(using `involucro/involucro` would not be free, so...)