### PR TITLE
Remove string prefix stripping, use path prefix matching

### DIFF
--- a/integrationtest/wrap_without_workdir_test.go
+++ b/integrationtest/wrap_without_workdir_test.go
@@ -1,0 +1,63 @@
+
+package integrationtest
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsouza/go-dockerclient"
+	"github.com/involucro/involucro/app"
+)
+
+func TestWrapCurrentDir(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	dir, err := ioutil.TempDir("", "inttest-58")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "a"), []byte("123"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := docker.NewClientFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		c.RemoveImage("inttest/58")
+		os.Chdir(cwd)
+	}()
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.Main([]string{
+		"involucro",
+		"-e",
+		"inv.task('wrap').wrap('.').inImage('busybox').at('/data').as('inttest/15')",
+		"wrap",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.Main([]string{
+		"involucro",
+		"-e",
+		"inv.task('x').using('inttest/15').run('grep', '123', '/data/a')",
+		"x",
+	}); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/wrap.go
+++ b/internal/wrap.go
@@ -255,7 +255,7 @@ func packItUp(sourceDirectory string, tarfile io.Writer, prefix string) error {
 				return err
 			}
 
-			symlinkTarget = preparePathForTarHeader(symlinkOsTarget, sourceDirectory, prefix)
+			symlinkTarget = filepath.ToSlash(symlinkOsTarget)
 		}
 
 		header, err := tar.FileInfoHeader(info, symlinkTarget)
@@ -291,11 +291,10 @@ func preparePathForTarHeader(filename string, sourceDir, prefix string) string {
 }
 
 func rebaseFilename(oldprefix, newprefix string, filename string) string {
-	withoutOld := strings.TrimPrefix(filename, oldprefix)
-	if withoutOld == filename {
-		return filename
+	withoutOld, err := filepath.Rel(oldprefix, filename)
+	if err != nil {
+		ilog.Warn.Logf("Unable to relativize %s with base %s: %v", filename, oldprefix, err)
 	}
-
 	return path.Join(newprefix, withoutOld)
 }
 


### PR DESCRIPTION
Currently, it is not possible to issue a `.wrap('.')` if the CLI parameter `-w` is not set. This is due to the use of String prefix matching in the tar packing code, leading to packing only the files that begin with `.` (e.g. `.git`).

Go provides `filepath.Rel` which is a safer way of doing what was intended here.